### PR TITLE
Fixed definition of `MainActivity` in the `AndroidManifest.xml`

### DIFF
--- a/SmartRemoteControl/src/main/AndroidManifest.xml
+++ b/SmartRemoteControl/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:theme="@style/AppTheme">
 
         <activity
-            android:name="MainActivity_"
+            android:name="MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
`MainActivity` was mentioned in the manifest file as `MainActivity_`, changed it to `MainActivity`.

Fixes issue #1.
